### PR TITLE
feat: automated auth capture + first-run setup wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,45 @@ config.toml
 /fansly-scraper
 .crush
 CRUSH.md
+
+# Logs
+.logs/
+logs/
+*.log
+*.log.*
+
+# SQLite databases
+downloads.db
+downloads.db-journal
+downloads.db-shm
+downloads.db-wal
+*.db
+*.sqlite
+*.sqlite3
+
+# Go build artifacts
+*.test
+*.out
+*.dll
+*.so
+*.dylib
+
+# Build output
+dist/
+bin/
+build/
+coverage.out
+
+# OS / Editor files
+.DS_Store
+Thumbs.db
+desktop.ini
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Environment files
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go install github.com/agnosto/fansly-scraper/cmd/fansly-scraper@latest
 ./fansly-scraper
 ```
 
-The program will create a [config](./config.md#location) file for you to edit on first run.
+On first run, the setup wizard helps you configure everything. Press 'a' to use auto login: it opens Fansly and provides a one‑line snippet to paste in DevTools Console. Your token and user‑agent are captured automatically and saved to the config.
 
 ## Basic Usage
 
@@ -33,6 +33,10 @@ The program will create a [config](./config.md#location) file for you to edit on
 ```bash
 ./fansly-scraper
 ```
+
+From the main menu you can:
+- Run setup wizard (choose save location, auto login)
+- Reset configuration (restore defaults, re-run wizard)
 
 ### Command Line Mode
 ```bash

--- a/auth/autocapture.go
+++ b/auth/autocapture.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+    "context"
+    "fmt"
+    "net"
+    "net/http"
+    "sync"
+)
+
+// CapturedInfo carries auth token and user agent captured from the browser.
+type CapturedInfo struct {
+    Token     string
+    UserAgent string
+}
+
+// StartAutoCaptureServer starts a local HTTP server on 127.0.0.1 that listens
+// for a GET request at /capture?token=...&ua=... and returns the chosen port,
+// a channel where the first captured credentials are delivered, and a shutdown
+// function to stop the server gracefully.
+func StartAutoCaptureServer() (port int, ch <-chan CapturedInfo, shutdown func(context.Context) error, err error) {
+    mux := http.NewServeMux()
+
+    outCh := make(chan CapturedInfo, 1)
+    var once sync.Once
+
+    mux.HandleFunc("/capture", func(w http.ResponseWriter, r *http.Request) {
+        q := r.URL.Query()
+        token := q.Get("token")
+        ua := q.Get("ua")
+
+        if token == "" || ua == "" {
+            w.WriteHeader(http.StatusBadRequest)
+            _, _ = w.Write([]byte("missing token or ua"))
+            return
+        }
+
+        once.Do(func() {
+            outCh <- CapturedInfo{Token: token, UserAgent: ua}
+            close(outCh)
+        })
+
+        w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+        w.Header().Set("Cache-Control", "no-store")
+        _, _ = w.Write([]byte("OK"))
+    })
+
+    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        // A minimal landing page with instructions.
+        // Users typically won’t open this; the TUI shows instructions/snippet.
+        w.Header().Set("Content-Type", "text/html; charset=utf-8")
+        _, _ = w.Write([]byte(`<html><head><title>Fansly Scraper Capture</title></head><body>
+<h3>Fansly Scraper: Token Capture</h3>
+<p>This page is used by the scraper to receive your token from your browser.</p>
+<p>Open fansly.com, log in, open DevTools Console and run the snippet shown in the scraper.</p>
+</body></html>`))
+    })
+
+    srv := &http.Server{Handler: mux}
+
+    // Listen on 127.0.0.1:0 (auto-assign free port)
+    ln, e := net.Listen("tcp", "127.0.0.1:0")
+    if e != nil {
+        return 0, nil, nil, e
+    }
+
+    // Extract the chosen port
+    addr := ln.Addr().String()
+    // addr like 127.0.0.1:54321
+    var p int
+    if _, e := fmt.Sscanf(addr, "127.0.0.1:%d", &p); e != nil {
+        // fallback: parse by splitting
+        host, portStr, _ := net.SplitHostPort(addr)
+        if host == "" || portStr == "" {
+            _ = ln.Close()
+            return 0, nil, nil, e
+        }
+        var pe error
+        _, pe = fmt.Sscanf(portStr, "%d", &p)
+        if pe != nil {
+            _ = ln.Close()
+            return 0, nil, nil, pe
+        }
+    }
+
+    go func() {
+        _ = srv.Serve(ln)
+    }()
+
+    shutdown = func(ctx context.Context) error {
+        return srv.Shutdown(ctx)
+    }
+
+    return p, outCh, shutdown, nil
+}
+

--- a/config.md
+++ b/config.md
@@ -27,7 +27,13 @@ This document outlines available options for the Scraper.
 <details>
 <summary><strong>Getting your token</strong></summary>
 
-### Method 1 (Recommended) special thanks to [prof79](https://github.com/prof79/)'s wiki for this:
+### Method 0 (Easiest): Use the Setup Wizard
+
+- When the app starts for the first time, choose auto login in the setup wizard by pressing `a`.
+- It will start a local capture on `http://127.0.0.1:<port>/capture` and show a one‑line snippet.
+- Press `o` to open fansly.com, log in, open DevTools Console, press `c` in the wizard to copy the snippet, paste it into the Console and hit Enter. Your token and user‑agent will be filled automatically.
+
+### Method 1 (Manual Console)
 
 1. Go to [fansly](https://fansly.com) and login and open devtools (ctrl+shift+i / F12)
 2. In devtools, go to the Console Tab and Paste the following: 
@@ -40,7 +46,7 @@ console.log('%c➡️ Authorization_Token =', 'font-size: 12px; color: limegreen
 console.log('%c➡️ User_Agent =', 'font-size: 12px; color: yellow; font-weight: bold;', navigator.userAgent); // show user-agent
 ```
 
-### Method 2:
+### Method 2 (Manual Storage View):
 1. Go to [fansly](https://fansly.com) and login and open devtools (ctrl+shift+i / F12)
 2. Click on `Storage` and then `Local Storage`
 3. Look for `session_active_session` and copy the `token` value

--- a/config/config_updater.go
+++ b/config/config_updater.go
@@ -329,3 +329,19 @@ func downloadFile(url, filePath string) error {
 	_, err = io.Copy(out, resp.Body)
 	return err
 }
+
+// ResetConfig removes the current config file (if present) and writes a fresh
+// default config. This does not preserve any previous values.
+func ResetConfig() error {
+    configPath := GetConfigPath()
+    // Best-effort remove existing file
+    _ = os.Remove(configPath)
+    // Ensure directory exists without creating a config file
+    if err := os.MkdirAll(filepath.Dir(configPath), os.ModePerm); err != nil {
+        return err
+    }
+    // Overwrite with a pristine default config
+    defaultConfig := CreateDefaultConfig()
+    // SaveConfig will not merge since we removed the file
+    return SaveConfig(defaultConfig)
+}

--- a/config/config_updater.go
+++ b/config/config_updater.go
@@ -333,15 +333,15 @@ func downloadFile(url, filePath string) error {
 // ResetConfig removes the current config file (if present) and writes a fresh
 // default config. This does not preserve any previous values.
 func ResetConfig() error {
-    configPath := GetConfigPath()
-    // Best-effort remove existing file
-    _ = os.Remove(configPath)
-    // Ensure directory exists without creating a config file
-    if err := os.MkdirAll(filepath.Dir(configPath), os.ModePerm); err != nil {
-        return err
-    }
-    // Overwrite with a pristine default config
-    defaultConfig := CreateDefaultConfig()
-    // SaveConfig will not merge since we removed the file
-    return SaveConfig(defaultConfig)
+	configPath := GetConfigPath()
+	// Best-effort remove existing file
+	_ = os.Remove(configPath)
+	// Ensure directory exists without creating a config file
+	if err := os.MkdirAll(filepath.Dir(configPath), os.ModePerm); err != nil {
+		return err
+	}
+	// Overwrite with a pristine default config
+	defaultConfig := CreateDefaultConfig()
+	// SaveConfig will not merge since we removed the file
+	return SaveConfig(defaultConfig)
 }

--- a/ui/config_wizard.go
+++ b/ui/config_wizard.go
@@ -1,101 +1,364 @@
 package ui
 
 import (
-	"path/filepath"
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "runtime"
+    "strings"
+    "time"
 
-	"github.com/agnosto/fansly-scraper/config"
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
+    "github.com/agnosto/fansly-scraper/auth"
+    "github.com/agnosto/fansly-scraper/config"
+    "github.com/charmbracelet/bubbles/textinput"
+    tea "github.com/charmbracelet/bubbletea"
+    "github.com/atotto/clipboard"
+    "os/exec"
 )
 
 type ConfigWizardModel struct {
-	state   int
-	inputs  [3]textinput.Model
-	cursor  int
-	message string
+    state   int
+    inputs  [3]textinput.Model
+    cursor  int
+    message string
+    // Location step
+    locOptions   []string
+    locCursor    int
+    locCustom    bool
+    locInput     textinput.Model
+    locMessage   string
+    selectedPath string
+    // Auto-capture state
+    autoActive bool
+    autoPort   int
+    snippet    string
+    waiting    bool
+    stopFn     func(ctx context.Context) error
 }
 
 const (
-	wizardSaveLocation = iota
-	wizardUserAgent
-	wizardAuthToken
+    wizardStepLocation = iota
+    wizardStepLogin
 )
 
 func NewConfigWizardModel() *ConfigWizardModel {
-	m := &ConfigWizardModel{}
-	m.inputs[0] = textinput.New()
-	m.inputs[0].Placeholder = "Save location (folder)"
-	m.inputs[0].Focus()
-	m.inputs[1] = textinput.New()
-	m.inputs[1].Placeholder = "HTTP User-Agent"
-	m.inputs[2] = textinput.New()
-	m.inputs[2].Placeholder = "Auth token"
-	m.inputs[2].EchoMode = textinput.EchoPassword
-	m.inputs[2].EchoCharacter = '•'
-	return m
+    m := &ConfigWizardModel{}
+    m.state = wizardStepLocation
+    // Pre-create inputs for login step
+    m.inputs[0] = textinput.New()
+    m.inputs[0].Placeholder = "Save location (folder)"
+    m.inputs[1] = textinput.New()
+    m.inputs[1].Placeholder = "HTTP User-Agent"
+    m.inputs[2] = textinput.New()
+    m.inputs[2].Placeholder = "Auth token"
+    m.inputs[2].EchoMode = textinput.EchoPassword
+    m.inputs[2].EchoCharacter = '•'
+
+    // Location selection setup
+    m.locInput = textinput.New()
+    m.locInput.Placeholder = "Custom save location"
+
+    // Build options based on OS
+    exePath, _ := os.Executable()
+    exeDir := filepath.Dir(exePath)
+    home, _ := os.UserHomeDir()
+    downloads := filepath.Join(home, "Downloads", "fansly")
+    exeDefault := filepath.Join(exeDir, "content")
+    homeDefault := filepath.Join(home, "fansly-content")
+    m.locOptions = []string{
+        fmt.Sprintf("Use exe folder (create): %s", exeDefault),
+        fmt.Sprintf("Use home folder: %s", homeDefault),
+        fmt.Sprintf("Use Downloads: %s", downloads),
+        "Enter custom path...",
+    }
+    m.locCursor = 0
+    return m
 }
 
 func (m *ConfigWizardModel) Init() tea.Cmd { return textinput.Blink }
 
 func (m *ConfigWizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c":
-			return m, tea.Quit
-		case "esc":
-			m.message = "Setup cancelled."
-			return m, tea.Quit
-		case "enter":
-			if m.cursor < len(m.inputs)-1 {
-				m.cursor++
-				m.inputs[m.cursor].Focus()
-				return m, nil
-			}
-			cfg := config.CreateDefaultConfig()
-			cfg.Options.SaveLocation = filepath.Clean(m.inputs[0].Value())
-			cfg.Account.UserAgent = m.inputs[1].Value()
-			cfg.Account.AuthToken = m.inputs[2].Value()
-			if err := config.ValidateConfig(cfg, config.GetConfigPath()); err != nil {
-				m.message = err.Error()
-				return m, nil
-			}
-			if err := config.EnsureConfigExists(config.GetConfigPath()); err != nil {
-				m.message = err.Error()
-				return m, nil
-			}
-			if err := config.SaveConfig(cfg); err != nil {
-				m.message = err.Error()
-				return m, nil
-			}
-			return m, tea.Quit
-		case "tab":
-			m.cursor = (m.cursor + 1) % len(m.inputs)
-			for i := range m.inputs {
-				if i == m.cursor {
-					m.inputs[i].Focus()
-				} else {
-					m.inputs[i].Blur()
-				}
-			}
-		}
-	}
+    switch msg := msg.(type) {
+    case tea.KeyMsg:
+        switch m.state {
+        case wizardStepLocation:
+            switch msg.String() {
+            case "ctrl+c":
+                if m.stopFn != nil {
+                    _ = m.stopFn(context.Background())
+                    m.stopFn = nil
+                }
+                return m, tea.Quit
+            case "esc":
+                if m.stopFn != nil {
+                    _ = m.stopFn(context.Background())
+                    m.stopFn = nil
+                }
+                m.message = "Setup cancelled."
+                return m, tea.Quit
+            case "up":
+                if !m.locCustom {
+                    m.locCursor = (m.locCursor - 1 + len(m.locOptions)) % len(m.locOptions)
+                }
+            case "down":
+                if !m.locCustom {
+                    m.locCursor = (m.locCursor + 1) % len(m.locOptions)
+                }
+            case "enter":
+                if m.locCustom {
+                    path := strings.TrimSpace(m.locInput.Value())
+                    if path == "" {
+                        m.locMessage = "Please enter a valid path."
+                        return m, nil
+                    }
+                    m.selectedPath = filepath.Clean(path)
+                    if err := os.MkdirAll(m.selectedPath, os.ModePerm); err != nil {
+                        m.locMessage = fmt.Sprintf("Failed to create folder: %v", err)
+                        return m, nil
+                    }
+                    // proceed to login step
+                    m.inputs[0].SetValue(m.selectedPath)
+                    m.state = wizardStepLogin
+                    m.inputs[1].Focus()
+                    m.locMessage = ""
+                    return m, nil
+                }
+                // Not in custom mode: process selection
+                switch m.locCursor {
+                case 0, 1, 2:
+                    // Parse the path portion from the option label after ': '
+                    parts := strings.SplitN(m.locOptions[m.locCursor], ": ", 2)
+                    if len(parts) == 2 {
+                        m.selectedPath = filepath.Clean(parts[1])
+                    }
+                    if m.selectedPath == "" {
+                        m.locMessage = "Internal error: empty path"
+                        return m, nil
+                    }
+                    if err := os.MkdirAll(m.selectedPath, os.ModePerm); err != nil {
+                        m.locMessage = fmt.Sprintf("Failed to create folder: %v", err)
+                        return m, nil
+                    }
+                    m.inputs[0].SetValue(m.selectedPath)
+                    m.state = wizardStepLogin
+                    m.inputs[1].Focus()
+                    return m, nil
+                case 3:
+                    // Enable custom input
+                    m.locCustom = true
+                    m.locInput.Focus()
+                    return m, nil
+                }
+            }
+        case wizardStepLogin:
+            switch msg.String() {
+            case "ctrl+c":
+                return m, tea.Quit
+            case "esc":
+                m.message = "Setup cancelled."
+                return m, tea.Quit
+            case "a":
+                if !m.autoActive {
+                    m.message = "Starting browser auto-capture..."
+                    m.waiting = true
+                    return m, m.startAutoCaptureCmd()
+                }
+            case "o":
+                _ = openURL("https://fansly.com/")
+                return m, nil
+            case "c":
+                if m.snippet != "" {
+                    if err := clipboard.WriteAll(m.snippet); err != nil {
+                        m.message = "Failed to copy snippet to clipboard."
+                    } else {
+                        m.message = "Snippet copied. Paste in Fansly DevTools Console and press Enter."
+                    }
+                    return m, nil
+                }
+            case "enter":
+                if m.cursor == 0 { // ensure cursor starts on UA field
+                    m.cursor = 1
+                }
+                if m.cursor < len(m.inputs)-1 {
+                    m.cursor++
+                    m.inputs[m.cursor].Focus()
+                    return m, nil
+                }
+                cfg := config.CreateDefaultConfig()
+                cfg.Options.SaveLocation = filepath.Clean(m.inputs[0].Value())
+                cfg.Account.UserAgent = m.inputs[1].Value()
+                cfg.Account.AuthToken = m.inputs[2].Value()
+                if err := config.ValidateConfig(cfg, config.GetConfigPath()); err != nil {
+                    m.message = err.Error()
+                    return m, nil
+                }
+                if err := config.EnsureConfigExists(config.GetConfigPath()); err != nil {
+                    m.message = err.Error()
+                    return m, nil
+                }
+                if err := config.SaveConfig(cfg); err != nil {
+                    m.message = err.Error()
+                    return m, nil
+                }
+                return m, tea.Quit
+            case "tab":
+                m.cursor = (m.cursor + 1) % len(m.inputs)
+                for i := range m.inputs {
+                    if i == m.cursor {
+                        m.inputs[i].Focus()
+                    } else {
+                        m.inputs[i].Blur()
+                    }
+                }
+            }
+        }
+    case autoCaptureStartedMsg:
+        m.autoActive = true
+        m.autoPort = msg.Port
+        m.stopFn = msg.Stop
+        m.snippet = buildCaptureSnippet(msg.Port)
+        // After starting, wait for result
+        return m, m.waitForCaptureCmd(msg.Ch)
+    case autoCaptureResultMsg:
+        m.waiting = false
+        if msg.Err != nil {
+            m.message = fmt.Sprintf("Auto-capture failed: %v", msg.Err)
+            return m, nil
+        }
+        // Fill inputs automatically
+        m.inputs[1].SetValue(msg.UserAgent)
+        m.inputs[2].SetValue(msg.Token)
+        m.message = "Captured token and user-agent from browser. Press Enter to save."
+        // Stop server
+        if m.stopFn != nil {
+            _ = m.stopFn(context.Background())
+            m.stopFn = nil
+        }
+        return m, nil
+    }
 
-	for i := range m.inputs {
-		m.inputs[i], _ = m.inputs[i].Update(msg)
-	}
-	return m, nil
+    switch m.state {
+    case wizardStepLocation:
+        if m.locCustom {
+            m.locInput, _ = m.locInput.Update(msg)
+        }
+    case wizardStepLogin:
+        for i := range m.inputs {
+            m.inputs[i], _ = m.inputs[i].Update(msg)
+        }
+    }
+    return m, nil
 }
 
 func (m *ConfigWizardModel) View() string {
-	v := "First-time minimal setup: create config.toml\n\n"
-	v += "Windows: use forward slashes (C:/path/to/dir) or right-click to paste then escape backslashes (C:\\\\path\\\\to\\\\dir).\n\n"
-	v += m.inputs[0].View() + "\n"
-	v += m.inputs[1].View() + "\n"
-	v += m.inputs[2].View() + "\n\n"
-	if m.message != "" {
-		v += m.message + "\n"
-	}
-	v += "Press Enter to save, Tab to switch, Esc to quit. More settings under 'Edit config.toml file' in the main menu.\n"
-	return v
+    var b strings.Builder
+    switch m.state {
+    case wizardStepLocation:
+        b.WriteString("First-time setup: choose save location\n\n")
+        for i, opt := range m.locOptions {
+            if i == m.locCursor && !m.locCustom {
+                b.WriteString("> " + opt + "\n")
+            } else {
+                b.WriteString("  " + opt + "\n")
+            }
+        }
+        b.WriteString("\n")
+        if m.locCustom {
+            b.WriteString("Custom path: " + m.locInput.View() + "\n")
+            b.WriteString("Press Enter to confirm, Esc to cancel.\n")
+        } else {
+            b.WriteString("Use Up/Down to select, Enter to confirm. Esc to quit.\n")
+        }
+        if m.locMessage != "" {
+            b.WriteString(m.locMessage + "\n")
+        }
+    case wizardStepLogin:
+        b.WriteString("First-time setup: login\n\n")
+        b.WriteString("Save location: " + m.inputs[0].Value() + "\n\n")
+        b.WriteString("Auto login (recommended): press 'a' to start capture.\n")
+        if m.autoActive {
+            b.WriteString(fmt.Sprintf("Listening on http://127.0.0.1:%d/capture\n", m.autoPort))
+            b.WriteString("- Press 'o' to open fansly.com in your browser.\n")
+            b.WriteString("- Press 'c' to copy the capture snippet to clipboard, then paste in DevTools Console and press Enter.\n")
+            if m.snippet != "" {
+                preview := m.snippet
+                if len(preview) > 120 {
+                    preview = preview[:120] + "..."
+                }
+                b.WriteString("Snippet preview: " + preview + "\n")
+            }
+            if m.waiting {
+                b.WriteString("Waiting for browser to send details...\n")
+            }
+        } else {
+            b.WriteString("(This will auto-fill User-Agent and Token below.)\n")
+        }
+        b.WriteString("\n")
+        // Manual inputs still available
+        b.WriteString(m.inputs[1].View() + "\n")
+        b.WriteString(m.inputs[2].View() + "\n\n")
+        if m.message != "" {
+            b.WriteString(m.message + "\n")
+        }
+        b.WriteString("Press Enter to save, Tab to switch, Esc to quit.\n")
+    }
+    return b.String()
+}
+
+// Messages and commands for auto-capture flow
+type autoCaptureStartedMsg struct {
+    Port int
+    Ch   <-chan auth.CapturedInfo
+    Stop func(ctx context.Context) error
+}
+
+type autoCaptureResultMsg struct {
+    UserAgent string
+    Token     string
+    Err       error
+}
+
+func (m *ConfigWizardModel) startAutoCaptureCmd() tea.Cmd {
+    return func() tea.Msg {
+        port, ch, stop, err := auth.StartAutoCaptureServer()
+        if err != nil {
+            return autoCaptureResultMsg{Err: err}
+        }
+        return autoCaptureStartedMsg{Port: port, Ch: ch, Stop: stop}
+    }
+}
+
+func (m *ConfigWizardModel) waitForCaptureCmd(ch <-chan auth.CapturedInfo) tea.Cmd {
+    return func() tea.Msg {
+        select {
+        case res, ok := <-ch:
+            if !ok {
+                return autoCaptureResultMsg{Err: fmt.Errorf("capture channel closed")}
+            }
+            return autoCaptureResultMsg{UserAgent: res.UserAgent, Token: res.Token}
+        case <-time.After(5 * time.Minute):
+            if m.stopFn != nil {
+                _ = m.stopFn(context.Background())
+                m.stopFn = nil
+            }
+            return autoCaptureResultMsg{Err: fmt.Errorf("timed out waiting for capture")}
+        }
+    }
+}
+
+func buildCaptureSnippet(port int) string {
+    // Use an Image beacon to avoid CORS preflight; keep it short.
+    return fmt.Sprintf(`(function(){try{var s=localStorage.getItem('session_active_session');var t=s?JSON.parse(s).token:'';var u=navigator.userAgent;var i=new Image();i.src='http://127.0.0.1:%d/capture?token='+encodeURIComponent(t)+'&ua='+encodeURIComponent(u)+'&ts='+Date.now();console.log('Sent token to scraper at localhost');}catch(e){console.log('Capture error',e);}})();`, port)
+}
+
+func openURL(url string) error {
+    switch runtime.GOOS {
+    case "windows":
+        return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+    case "darwin":
+        return exec.Command("open", url).Start()
+    default:
+        return exec.Command("xdg-open", url).Start()
+    }
 }

--- a/ui/main_menu.go
+++ b/ui/main_menu.go
@@ -138,6 +138,27 @@ func (m *MainModel) handleMainMenuSelection() (tea.Model, tea.Cmd) {
 			}
 			return editConfigFinishedMsg{}
 		})
+	case "Run setup wizard":
+		return m, func() tea.Msg {
+			p := tea.NewProgram(NewConfigWizardModel())
+			if _, err := p.Run(); err != nil {
+				logger.Logger.Printf("Error running setup wizard: %v", err)
+			}
+			return setupWizardFinishedMsg{}
+		}
+	case "Reset configuration":
+		return m, func() tea.Msg {
+			if err := config.ResetConfig(); err != nil {
+				logger.Logger.Printf("Error resetting config: %v", err)
+				return setupWizardFinishedMsg{}
+			}
+			logger.Logger.Printf("Configuration reset to defaults. Launching setup wizard...")
+			p := tea.NewProgram(NewConfigWizardModel())
+			if _, err := p.Run(); err != nil {
+				logger.Logger.Printf("Error running setup wizard after reset: %v", err)
+			}
+			return setupWizardFinishedMsg{}
+		}
 	case "Quit":
 		m.quit = true
 		return m, tea.Quit

--- a/ui/model.go
+++ b/ui/model.go
@@ -123,6 +123,7 @@ type editConfigMsg struct {
 }
 
 type editConfigFinishedMsg struct{}
+type setupWizardFinishedMsg struct{}
 
 type downloadErrorMsg struct {
 	Error error
@@ -223,17 +224,19 @@ func (m *MainModel) Init() tea.Cmd {
 }
 
 func NewMainModel(downloader *download.Downloader, version string, monitoringService *service.MonitoringService) *MainModel {
-	return &MainModel{
-		version: version,
-		options: []string{
-			"Download a user's post",
-			"Download purchased content",
-			"Monitor a user's livestreams",
-			"Like all of a user's post",
-			"Unlike all of a user's post",
-			"Edit config.toml file",
-			"Quit",
-		},
+    return &MainModel{
+        version: version,
+        options: []string{
+            "Download a user's post",
+            "Download purchased content",
+            "Monitor a user's livestreams",
+            "Like all of a user's post",
+            "Unlike all of a user's post",
+            "Run setup wizard",
+            "Reset configuration",
+            "Edit config.toml file",
+            "Quit",
+        },
 		downloadOptions:   []string{"All", "Timeline", "Messages", "Stories"},
 		cursorPos:         0,
 		keys:              defaultKeyMap,


### PR DESCRIPTION

### Summary

Adds an automated login flow and a guided setup wizard to simplify first-time configuration. Users can press "a" in the wizard to start a local capture server and paste a one-line snippet into Fansly DevTools Console to securely send their auth token and user agent to the app. Also adds `ResetConfig` that writes a pristine default config, improves config creation/update logic, and expands `.gitignore` to exclude local DB/log files.

### What’s Included

*   **Auth Capture:** A local loopback receiver on `127.0.0.1:<ephemeral>` to capture the token + UA from a one-line snippet; features a single-use channel and graceful shutdown.
*   **First-Run Setup Wizard:** Includes location selection (with sensible defaults + custom paths), an auto-login flow ("a" to start, "o" to open Fansly, "c" to copy snippet), and continues to support manual entry.
*   **Config Handling:** `ResetConfig()` writes a pristine default config; `EnsureConfigExists()` cascades (example → default → download); `EnsureConfigUpdated()` inspects raw TOML to inject new defaults without clobbering user values.
*   **CLI/TUI Flow:** On a missing or invalid config, the TUI wizard runs automatically; CLI flags remain unchanged.
*   **Repo Hygiene:** `.gitignore` now ignores `.logs/`, `logs/`, `*.log`, `downloads.db` (+journal/shm/wal), `*.db`, and common build/editor files.

### Key Files

*   `auth/autocapture.go`
*   `ui/config_wizard.go`
*   `ui/main_menu.go`
*   `ui/model.go`
*   `cmd/fansly-scraper/main.go`
*   `config/config_updater.go`
*   `README.md`
*   `config.md`
*   `.gitignore`

### How It Works

1.  The wizard binds to `127.0.0.1:0` and listens for a request at `/capture?token=...&ua=...`.
2.  Pressing "o" opens Fansly, and "c" copies a short snippet that reads `localStorage.session_active_session.token` and `navigator.userAgent`, then sends it to `http://127.0.0.1:<port>/capture`.
3.  On the first successful request, the server closes its channel and shuts down. The wizard then fills the UA/token fields and prompts the user to save the configuration.

### Security Considerations

*   The server is loopback-only (`127.0.0.1`), uses an ephemeral port, is single-use, and has a 5-minute timeout.
*   Nothing is saved to disk until the user explicitly confirms and writes the config file.
*   Users with unusual localhost proxies should verify there is no external exposure.

### Behavior Changes

*   “Reset configuration” now resets to a pristine default and immediately relaunches the setup wizard.
*   The first run of the application, or any run with an invalid/missing config, launches the wizard.

### Testing

*   **Fresh run:** start app → wizard opens → choose save location → press "a" → press "o" to open Fansly → press "c" to copy snippet → paste in DevTools Console → UA/token auto-fill → save.
*   **Manual entry:** Fill UA/token manually in the wizard and save.
*   **Reset path:** Choose “Reset configuration” from the main menu; verify the wizard relaunches.
*   **Git:** Verify `downloads.db` and log files/directories are untracked by Git.

### Release Notes

*   **New:** Added an automated auth capture flow and a first-run setup wizard to simplify initial configuration.
*   **New:** The "Reset configuration" option now writes a clean default config and relaunches the setup wizard.
*   **Improved:** Enhanced the resiliency of config creation and updates, and expanded `.gitignore` to better handle local artifacts.